### PR TITLE
Serve index via HTTP and share port with WebSocket

### DIFF
--- a/poker-game/server.js
+++ b/poker-game/server.js
@@ -1,8 +1,54 @@
 import { WebSocketServer } from 'ws';
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import GameState from './src/game/GameState.js';
 import { GAME_PHASES } from './src/utils/constants.js';
 
-const wss = new WebSocketServer({ port: 8080 });
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function requestHandler(req, res) {
+  if (req.method === 'GET' && req.url === '/') {
+    const indexPath = path.join(__dirname, 'index.html');
+    fs.readFile(indexPath, (err, data) => {
+      if (err) {
+        res.writeHead(500);
+        res.end('Error loading page');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(data);
+    });
+  } else {
+    const filePath = path.join(__dirname, req.url);
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+      const ext = path.extname(filePath).toLowerCase();
+      const mimeTypes = {
+        '.js': 'application/javascript',
+        '.css': 'text/css',
+        '.html': 'text/html',
+        '.json': 'application/json',
+        '.png': 'image/png',
+        '.jpg': 'image/jpeg',
+        '.jpeg': 'image/jpeg',
+        '.gif': 'image/gif',
+        '.svg': 'image/svg+xml',
+      };
+      res.writeHead(200, { 'Content-Type': mimeTypes[ext] || 'application/octet-stream' });
+      res.end(data);
+    });
+  }
+}
+
+const server = http.createServer(requestHandler);
+const wss = new WebSocketServer({ server });
 const game = new GameState();
 const players = [];
 
@@ -66,4 +112,4 @@ wss.on('connection', (ws) => {
   });
 });
 
-console.log('Poker server running on ws://localhost:8080');
+server.listen(8080, () => console.log('Poker server running on http://localhost:8080'));


### PR DESCRIPTION
## Summary
- serve `index.html` over HTTP alongside static assets and WebSocket connections
- share a single HTTP server with the WebSocket server and log listening URL

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689aa5a1c2ec8326af1574813aabe17b